### PR TITLE
Correct character encoding in query-parameter

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -151,7 +151,7 @@ ___SANDBOXED_JS_FOR_SERVER___
 const getClientName = require('getClientName');
 const getAllEventData = require('getAllEventData');
 const sendHttpGet = require('sendHttpGet');
-const encodeUri = require('encodeUri');
+const encodeUri = require('encodeUriComponent');
 const logToConsole = require('logToConsole');
 
 // Get the name of the tagging client used
@@ -194,11 +194,11 @@ const buildRequest = (eventData) => {
   // Add common tracking request parameters (that won't change regardless of the event type)
   let requestPath = requestEndpoint + '?' +
         'rec=1' + '&' +
-        'idsite=' + data.siteID + '&' +
-        'url=' + eventData.page_location + '&' +
-        'cip=' + eventData.ip_override + '&' +
-        'ua=' + eventData.user_agent + '&' +
-        'res=' + eventData.screen_resolution;
+        'idsite=' + encodeUriComponent(data.siteID) + '&' +
+        'url=' + encodeUriComponent(eventData.page_location) + '&' +
+        'cip=' + encodeUriComponent(eventData.ip_override) + '&' +
+        'ua=' + encodeUriComponent(eventData.user_agent) + '&' +
+        'res=' + encodeUriComponent(eventData.screen_resolution);
   
   if (data.anonymousTracking == true) {
     requestPath += '&uia=1';
@@ -213,14 +213,14 @@ const buildRequest = (eventData) => {
   switch (eventType) {
     case 'page_view':
       return requestPath + '&' +
-        'action_name=' + eventData.page_title;
+        'action_name=' + encodeUriComponent(eventData.page_title);
   
     // Custom events the same event type as the event action parameter
     case eventData.event_action:
       return requestPath + '&' +
-        'e_c=' + eventData.event_category + '&' +
-        'e_a=' + eventData.event_action + '&' +
-        'e_n=' + eventData.event_label;
+        'e_c=' + encodeUriComponent(eventData.event_category) + '&' +
+        'e_a=' + encodeUriComponent(eventData.event_action) + '&' +
+        'e_n=' + encodeUriComponent(eventData.event_label);
   }
 };
 
@@ -228,7 +228,7 @@ const buildRequest = (eventData) => {
 const requestPath = buildRequest(eventData);
 
 // Build the full URL for sending the request
-const url = data.accountURL + encodeUri(requestPath);
+const url = data.accountURL + requestPath;
 
 // The sendHttpGet API takes a URL and a result callback. You must call
 // data.gtmOnSuccess() or data.gtmOnFailure() so that the container knows when


### PR DESCRIPTION
Changed generic encodeUri to encodeUriComponent to avoid any bugs with characters like & in strings.